### PR TITLE
背景全面覆盖

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -11,6 +11,7 @@ body {
   font-family: 'Hiragino Sans GB', sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+  background-color: #f7f4e3;
 }
 
 html,

--- a/src/views/ContentView.vue
+++ b/src/views/ContentView.vue
@@ -49,7 +49,6 @@ const angle = Math.random().toPrecision(2)
 #container {
   width: 100%;
   height: 100%;
-  background-color: #f7f4e3;
   display: flex;
   align-items: center;
   justify-content: center;


### PR DESCRIPTION
有时内容旋转过度会导致溢出，滚动一下背景就会发现背景没有覆盖：

<img width="571" alt="image" src="https://user-images.githubusercontent.com/44045911/180806303-1cfd5a20-9376-4b92-9eca-5998455f173b.png">
